### PR TITLE
trinidad failing with default_web_xml

### DIFF
--- a/lib/trinidad/lifecycle/lifecycle_listener_default.rb
+++ b/lib/trinidad/lifecycle/lifecycle_listener_default.rb
@@ -14,12 +14,17 @@ module Trinidad
 
       def configure_deployment_descriptor(context)
         if descriptor = @webapp.default_deployment_descriptor
-          context.setDefaultWebXml(descriptor)
-
-          context_config = Trinidad::Tomcat::ContextConfig.new
+          listeners = context.findLifecycleListeners
+          context_config = listeners && listeners.find do |listener|
+            listener.is_a?(Trinidad::Tomcat::ContextConfig)
+          end
+          
+          unless context_config
+            context_config = Trinidad::Tomcat::ContextConfig.new
+            context.addLifecycleListener(context_config)
+          end
+          
           context_config.setDefaultWebXml(descriptor)
-
-          context.addLifecycleListener(context_config)
         end
         descriptor
       end


### PR DESCRIPTION
hey david, i discovered a strange issue with trinidad that relates to providing a web.xml deployment descriptor in `trinidad.yml` - somehow it kept failing with :

```
SEVERE: Marking this application unavailable due to previous error(s)
Apr 7, 2011 4:55:49 PM org.apache.catalina.core.StandardContext startInternal
SEVERE: Error getConfigured
Apr 7, 2011 4:55:49 PM org.apache.catalina.core.StandardContext startInternal
SEVERE: Context [/] startup failed due to previous errors
```

i've tried to dig into the tomcat API to understand what's happening while configuring the deployment descriptor, what i've found is that there's a `Trinidad::Tomcat::ContextConfig` already among the lifecycle listeners and when i use the one available instead of setting up a new one it magically starts working ...

pls take a look at it - i've setup a basic rails3 app where You can reproduce the issue :

https://github.com/kares/trinidad_web_xml

i also left a failing spec cause i'm really not 100% sure about my fix ...
