### PR TITLE
Hot Deploy without monitor file

### DIFF
--- a/lib/trinidad/web_app.rb
+++ b/lib/trinidad/web_app.rb
@@ -1,5 +1,7 @@
 module Trinidad
   class WebApp
+    DEFAULT_MONITORED_APP_DIRS = ['app', 'lib', 'public']
+
     attr_reader :config, :app_config, :class_loader, :servlet
 
     def self.create(config, app_config)
@@ -94,8 +96,13 @@ module Trinidad
     end
 
     def monitor
-      m_file = @app_config[:monitor] || @config[:monitor] || 'tmp/restart.txt'
-      File.expand_path(m_file, work_dir)
+      m_file = @app_config[:monitor] || @config[:monitor] || (DEFAULT_MONITORED_APP_DIRS + ['tmp/restart.txt'])
+      if m_file.is_a? Enumerable
+        m_file.map { |m| File.expand_path(m, work_dir)}
+      else
+        [File.expand_path(m_file, work_dir)]
+      end
+
     end
 
     def define_lifecycle

--- a/spec/trinidad/lifecycle/lifecycle_listener_host_spec.rb
+++ b/spec/trinidad/lifecycle/lifecycle_listener_host_spec.rb
@@ -18,7 +18,7 @@ describe "Trinidad::Lifecycle::Host" do
   let(:listener) do
     Trinidad::Lifecycle::Host.new(tomcat, {
       :context => context,
-      :monitor => monitor}
+      :monitor => [monitor]}
     )
   end
 
@@ -44,7 +44,7 @@ describe "Trinidad::Lifecycle::Host" do
     with_host_monitor do
       listener = Trinidad::Lifecycle::Host.new(tomcat, {
         :context => context,
-        :monitor => monitor}
+        :monitor => [monitor]}
       )
 
       listener.lifecycleEvent(start_event)
@@ -60,13 +60,13 @@ describe "Trinidad::Lifecycle::Host" do
     with_host_monitor do
       app = Trinidad::WebApp.create({}, {
         :web_app_dir => MOCK_WEB_APP_DIR,
-        :monitor => monitor
+        :monitor => [monitor]
       })
 
       applications = {
         :app => app,
         :context => context,
-        :monitor => monitor
+        :monitor => [monitor]
       }
 
       listener = Trinidad::Lifecycle::Host.new(tomcat, applications)
@@ -90,13 +90,13 @@ describe "Trinidad::Lifecycle::Host" do
     with_host_monitor do
       app = Trinidad::WebApp.create({}, {
         :web_app_dir => MOCK_WEB_APP_DIR,
-        :monitor => monitor
+        :monitor => [monitor]
       })
 
       applications = {
         :app => app,
         :context => context,
-        :monitor => monitor
+        :monitor => [monitor]
       }
 
       old_class_loader = app.class_loader
@@ -111,6 +111,129 @@ describe "Trinidad::Lifecycle::Host" do
       listener.lifecycleEvent periodic_event
 
       app.class_loader.should_not eq old_class_loader
+    end
+  end
+
+  describe "with file and dir monitors" do
+
+    let(:app_dir) { File.expand_path('mydir', MOCK_WEB_APP_DIR) }
+
+    let(:app_file) { File.expand_path('lib/some_file.rb', app_dir) }
+
+    let(:monitors) { [monitor, app_dir] }
+
+    let(:listener) do
+      Trinidad::Lifecycle::Host.new(tomcat, {
+        :context => context,
+        :monitor => monitors}
+      )
+    end
+
+    before do
+      unless File.exists?(app_file)
+        Dir.mkdir(File.dirname(app_file))
+        File.new(app_file, "w+")
+      end
+    end
+
+    after(:all) do
+      File.delete(app_file)
+    end
+
+    it "creates the monitor file when receives a before start event" do
+      File.exist?(monitor).should be_false
+      listener.lifecycleEvent(start_event)
+      sleep(1)
+      monitors.each do |m|
+        File.exist?(m).should be_true
+      end
+    end
+
+    it "does not create the monitor if already exists" do
+      file = File.new(monitor, File::CREAT|File::TRUNC)
+      mtime = file.mtime
+      app_dir_mtime = File.mtime(app_dir)
+      sleep(1)
+
+      listener.lifecycleEvent(start_event)
+
+
+      File.mtime(monitor).should == mtime
+      File.mtime(app_dir).should == app_dir_mtime
+    end
+
+    it "creates the parent directory if it doesn't exist" do
+      with_host_monitor do
+        listener = Trinidad::Lifecycle::Host.new(tomcat, {
+          :context => context,
+          :monitor => monitors}
+        )
+
+        listener.lifecycleEvent(start_event)
+        sleep(1)
+        File.exist?(monitor).should be_true
+      end
+    end
+
+    it "creates a new context that takes over the original one" do
+      context.expects(:path).once.returns('/foo')
+      context.expects(:parent).once.returns(tomcat.host)
+
+      with_host_monitor do
+        app = Trinidad::WebApp.create({}, {
+          :web_app_dir => MOCK_WEB_APP_DIR,
+          :monitor => monitors
+        })
+
+        applications = {
+          :app => app,
+          :context => context,
+          :monitor => monitors
+        }
+
+        listener = Trinidad::Lifecycle::Host.new(tomcat, applications)
+
+        listener.lifecycleEvent start_event
+        sleep(1)
+
+        File.new(app_file, File::CREAT|File::TRUNC)
+
+        listener.lifecycleEvent periodic_event
+
+        applications[:context].should be_instance_of(Trinidad::Tomcat::StandardContext)
+        applications[:context].should_not == context
+      end
+    end
+
+    it "creates a new JRuby class loader for the new context" do
+      context.expects(:path).once.returns('/foo')
+      context.expects(:parent).once.returns(tomcat.host)
+
+      with_host_monitor do
+        app = Trinidad::WebApp.create({}, {
+          :web_app_dir => MOCK_WEB_APP_DIR,
+          :monitor => monitors
+        })
+
+        applications = {
+          :app => app,
+          :context => context,
+          :monitor => monitors
+        }
+
+        old_class_loader = app.class_loader
+
+        listener = Trinidad::Lifecycle::Host.new(tomcat, applications)
+
+        listener.lifecycleEvent start_event
+        sleep(1)
+
+        File.new(app_file, File::CREAT|File::TRUNC)
+
+        listener.lifecycleEvent periodic_event
+
+        app.class_loader.should_not eq old_class_loader
+      end
     end
   end
 end

--- a/spec/trinidad/web_app_spec.rb
+++ b/spec/trinidad/web_app_spec.rb
@@ -261,7 +261,13 @@ describe Trinidad::WebApp do
     app = Trinidad::WebApp.create({
       :web_app_dir => MOCK_WEB_APP_DIR
     }, {})
-    app.monitor.should == File.expand_path('tmp/restart.txt', MOCK_WEB_APP_DIR)
+    app.monitor.size.should == 4
+    app.monitor.should include(
+                           File.expand_path('tmp/restart.txt', MOCK_WEB_APP_DIR),
+                           File.expand_path('app', MOCK_WEB_APP_DIR),
+                           File.expand_path('public', MOCK_WEB_APP_DIR),
+                           File.expand_path('lib', MOCK_WEB_APP_DIR))
+
   end
 
   it "accepts a monitor file as configuration parameter" do
@@ -269,7 +275,7 @@ describe Trinidad::WebApp do
       :web_app_dir => MOCK_WEB_APP_DIR,
       :monitor => 'foo.txt'
     }, {})
-    app.monitor.should == File.expand_path('foo.txt', MOCK_WEB_APP_DIR)
+    app.monitor.should == [File.expand_path('foo.txt', MOCK_WEB_APP_DIR)]
   end
 
   it "uses the war file to monitorize an application packed as a war" do

--- a/trinidad.gemspec
+++ b/trinidad.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   ## the sub! line in the Rakefile
   s.name              = 'trinidad'
   s.version           = '1.2.3'
-  s.date              = '2011-07-13'
+  s.date              = '2011-10-05'
   s.rubyforge_project = 'trinidad'
 
   ## Make sure your summary is short. The description may be as long

--- a/trinidad_jars.gemspec
+++ b/trinidad_jars.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   ## the sub! line in the Rakefile
   s.name              = 'trinidad_jars'
   s.version           = '1.0.2'
-  s.date              = '2011-09-10'
+  s.date              = '2011-10-05'
   s.rubyforge_project = 'trinidad_jars'
 
   ## Make sure your summary is short. The description may be as long


### PR DESCRIPTION
Hello, this patch adds support for hot deployment without touching the tmp/restart.txt.

It does this by adding a few things:
1) support for monitoring directories
2) support for monitoring multiple files and directories
3) monitoring app/, lib/ and public/ by default (more can be added in the trinidad.yml

Let me know what you think.  I fully expect to change this to meet your expectations.  

Thanks,

Joe
@codefinger
