### PR TITLE
Make work_dir configurable

### DIFF
--- a/lib/trinidad/web_app.rb
+++ b/lib/trinidad/web_app.rb
@@ -81,8 +81,8 @@ module Trinidad
       end
     end
 
-    def war?; WebApp.war?(app_config); end
-    def work_dir; web_app_dir; end
+    def war?; WebApp.war?(app_config); end    
+    def work_dir; @app_config[:work_dir] || @config[:work_dir] || web_app_dir; end
     def environment; @app_config[:environment] || @config[:environment] || 'development'; end
 
     def solo?


### PR DESCRIPTION
Makes it possible to work around this issue:
https://github.com/trinidad/trinidad_resque_extension/issues/2
