### PR TITLE
deeper symbolize_options

### DIFF
--- a/lib/trinidad/configuration.rb
+++ b/lib/trinidad/configuration.rb
@@ -90,8 +90,17 @@ module Trinidad
     # a Hash like #symbolize helper
     def self.symbolize_options(options, deep = true)
       new_options = options.class.new
-      options.each do |key, value|
-        if deep && options_like?(value)
+      options.each do |key, value|    
+        if deep && value.is_a?(Array)
+          new_options[key.to_sym] = []
+          value.each do |v|
+            if options_like?(v)
+              new_options[key.to_sym] << symbolize_options(v, deep) 
+            else
+              new_options[key.to_sym] << value
+            end
+          end
+        elsif deep && options_like?(value)
           new_options[key.to_sym] = symbolize_options(value, deep)
         else
           new_options[key.to_sym] = value

--- a/spec/trinidad/configuration_spec.rb
+++ b/spec/trinidad/configuration_spec.rb
@@ -49,9 +49,17 @@ describe Trinidad::Configuration do
     config2 = { 
       'port' => 2000,
       'environment' => 'production',
-      'http' => { :'connectionTimeout' => '30000', 'bufferSize' => 1025 }
+      'http' => { :'connectionTimeout' => '30000', 'bufferSize' => 1025 },
+      'web_apps' => { 'default' => { 'extensions' => { 'mysql_dbpool' => [
+              {'driver' => 'foo',
+                'host' => 'foo.net'
+              },
+              {'driver' => 'bar',
+                'host' => 'bar.net'
+              },       
+            ]}}}
     }
-    
+ 
     config = Trinidad.configure!(config1, config2)
     config[:port].should == 2000
     config['address'].should == 'local.host'
@@ -61,6 +69,13 @@ describe Trinidad::Configuration do
       :bufferSize => 1025,
       :connectionTimeout => '30000'
     }
+    config[:web_apps][:default][:extensions][:mysql_dbpool].should == [
+      {:driver => 'foo',
+        :host => 'foo.net'
+      },
+      {:driver => 'bar',
+        :host => 'bar.net'
+      }
+    ]
   end
-  
 end


### PR DESCRIPTION
This pull request allows symbolize_options to detect arrays and properly symbolize their values if they are hashes. Fixes issues with extensions that accept arrays: https://github.com/trinidad/trinidad_dbpool_extension/issues/6
