### PR TITLE
create Trinidad::Lifecycle::Host for apps bound to 0.0.0.0

### DIFF
--- a/lib/trinidad/server.rb
+++ b/lib/trinidad/server.rb
@@ -455,7 +455,7 @@ module Trinidad
     def select_host_apps(app_holders, host)
       app_holders.select do |app_holder|
         host_name = app_holder.web_app.host_name
-        ( host_name || 'localhost' ) == host.name
+        [host_name, 'localhost', '0.0.0.0'].include?(host.name)
       end
     end
 


### PR DESCRIPTION
We're trying to hot deploy an app bound to 0.0.0.0 and it doesn't work because only localhost is treated as a special case. I think this should be okay, no?

I wasn't sure this was worth creating a whole other fake app to test with, but if you feel differently, let me know.
